### PR TITLE
Install all include directories in /usr/include

### DIFF
--- a/build_all/packaging/linux/debian/azure-iot-sdk-c-twilio-dev.dirs
+++ b/build_all/packaging/linux/debian/azure-iot-sdk-c-twilio-dev.dirs
@@ -1,6 +1,10 @@
 usr/include
 usr/include/azureiot
+usr/include/azure_c_shared_utility
 usr/include/azure_macro_utils
 usr/include/azure_prov_client
+usr/include/azure_uamqp_c
+usr/include/azure_uhttp_c
+usr/include/azure_umqtt_c
 usr/include/iothub_service_client
 usr/include/umock_c

--- a/build_all/packaging/linux/debian/azure-iot-sdk-c-twilio-dev.install
+++ b/build_all/packaging/linux/debian/azure-iot-sdk-c-twilio-dev.install
@@ -1,5 +1,9 @@
 usr/include/azureiot/*
+usr/include/azure_c_shared_utility/*
 usr/include/azure_macro_utils/*
 usr/include/azure_prov_client/*
+usr/include/azure_uamqp_c/*
+usr/include/azure_uhttp_c/*
+usr/include/azure_umqtt_c/*
 usr/include/iothub_service_client/*
 usr/include/umock_c/*

--- a/build_all/packaging/linux/debian/rules
+++ b/build_all/packaging/linux/debian/rules
@@ -23,3 +23,10 @@ include /usr/share/dpkg/default.mk
 
 override_dh_auto_configure:
 	dh_auto_configure -- -Duse_openssl=ON -Duse_prov_client=ON -Dbuild_provisioning_service_client=ON -Ddont_use_uploadtoblob=ON ..
+
+override_dh_auto_install:
+	dh_auto_install -- prefix=/usr
+	mv $$(pwd)/debian/tmp/usr/include/azureiot/azure_c_shared_utility $$(pwd)/debian/tmp/usr/include
+	mv $$(pwd)/debian/tmp/usr/include/azureiot/azure_uamqp_c $$(pwd)/debian/tmp/usr/include
+	mv $$(pwd)/debian/tmp/usr/include/azureiot/azure_uhttp_c $$(pwd)/debian/tmp/usr/include
+	mv $$(pwd)/debian/tmp/usr/include/azureiot/azure_umqtt_c $$(pwd)/debian/tmp/usr/include


### PR DESCRIPTION
This way the package doesn't require a cmake module